### PR TITLE
Add l3out module and examples

### DIFF
--- a/examples/l3out/l3ouit_ospf_vpc_svi_nssa.tf
+++ b/examples/l3out/l3ouit_ospf_vpc_svi_nssa.tf
@@ -1,0 +1,64 @@
+
+module "ospf03_l3out" {
+  source = "./.."
+
+  name        = "ospf03_l3out"
+  alias       = ""
+  description = "L3Out-OSPF-VPC-svi-nssa"
+  tenant_dn   = aci_tenant.test.id
+  vrf_dn      = aci_vrf.test.id
+  l3dom_dn    = data.aci_l3_domain_profile.core.id
+
+  ospf = {
+    enabled   = true
+    area_id   = "0.0.0.8"
+    area_type = "nssa"
+    area_cost = "1"
+    # area_ctrl ommited, takes default value
+  }
+
+  nodes = {
+    "1101" = {
+      pod_id             = "1"
+      node_id            = "1101"
+      router_id          = "1.1.1.101"
+      router_id_loopback = "no"
+    },
+    "1102" = {
+      pod_id             = "1"
+      node_id            = "1102"
+      router_id          = "1.1.1.102"
+      router_id_loopback = "no"
+    }
+  }
+
+  interfaces = {
+    "vpc_core" = {
+      l2_port_type     = "vpc"
+      l3_port_type     = "ext-svi"
+      pod_id           = "1"
+      node_a_id        = "1101"
+      node_b_id        = "1102"
+      interface_id     = "vpc_core"
+      ip_addr_a        = "172.16.38.101/24"
+      ip_addr_b        = "172.16.38.102/24"
+      vlan_encap       = "vlan-38"
+      vlan_encap_scope = "local"
+      mode             = "regular"
+      mtu              = "9216"
+    }
+  }
+
+  external_l3epg = {
+    "default" = {
+      name         = "default"
+      pref_gr_memb = "exclude"
+      subnets = {
+        "default" = {
+          prefix = "0.0.0.0/0"
+          scope  = ["import-security"]
+        }
+      }
+    }
+  }
+}

--- a/examples/l3out/l3out_bgp_pc_routed_direct.tf
+++ b/examples/l3out/l3out_bgp_pc_routed_direct.tf
@@ -1,0 +1,58 @@
+module "bgp03_l3out" {
+  source = "./.."
+
+  name        = "bgp03_l3out"
+  alias       = ""
+  description = "L3Out-BGP-PC-Routed-direct"
+  tenant_dn   = aci_tenant.test.id
+  vrf_dn      = aci_vrf.test.id
+  l3dom_dn    = data.aci_l3_domain_profile.core.id
+
+  bgp = {
+    enabled = true
+  }
+
+  nodes = {
+    "1101" = {
+      pod_id             = "1"
+      node_id            = "1101"
+      router_id          = "1.1.1.101"
+      router_id_loopback = "no"
+    }
+  }
+
+  interfaces = {
+    "pc_core" = {
+      l2_port_type = "pc"
+      l3_port_type = "l3-port"
+      pod_id       = "1"
+      node_a_id    = "1101"
+      interface_id = "pc_core"
+      ip_addr_a    = "172.16.33.2/30"
+      mtu          = "9216"
+
+      bgp_peers = {
+        "core01" = {
+          peer_ip_addr     = "172.16.33.1"
+          peer_asn         = "65033"
+          addr_family_ctrl = "af-ucast"
+          bgp_ctrl         = "send-com,send-ext-com"
+          # Remaining attributes will use the default values
+        }
+      }
+    }
+  }
+
+  external_l3epg = {
+    "default" = {
+      name         = "default"
+      pref_gr_memb = "exclude"
+      subnets = {
+        "default" = {
+          prefix = "0.0.0.0/0"
+          scope  = ["import-security"]
+        }
+      }
+    }
+  }
+}

--- a/examples/l3out/l3out_bgp_port_subif_direct.tf
+++ b/examples/l3out/l3out_bgp_port_subif_direct.tf
@@ -1,0 +1,89 @@
+module "bgp02_l3out" {
+  source = "./.."
+
+  name        = "bgp02_l3out"
+  alias       = ""
+  description = "L3Out-BGP-Port-Subif-direct"
+  tenant_dn   = aci_tenant.test.id
+  vrf_dn      = aci_vrf.test.id
+  l3dom_dn    = data.aci_l3_domain_profile.core.id
+
+  bgp = {
+    enabled = true
+  }
+
+  nodes = {
+    "1101" = {
+      pod_id             = "1"
+      node_id            = "1101"
+      router_id          = "1.1.1.101"
+      router_id_loopback = "no"
+    },
+    "1102" = {
+      pod_id             = "1"
+      node_id            = "1102"
+      router_id          = "1.1.1.102"
+      router_id_loopback = "no"
+    }
+  }
+
+  interfaces = {
+    "1101_1_25" = {
+      l2_port_type     = "port"
+      l3_port_type     = "sub-interface"
+      pod_id           = "1"
+      node_a_id        = "1101"
+      interface_id     = "eth1/25"
+      ip_addr_a        = "172.16.32.10/30"
+      vlan_encap       = "vlan-32"
+      vlan_encap_scope = "local"
+      mode             = "regular"
+      mtu              = "9216"
+
+      bgp_peers = {
+        "core01" = {
+          peer_ip_addr     = "172.16.32.9"
+          peer_asn         = "65032"
+          addr_family_ctrl = "af-ucast"
+          bgp_ctrl         = "send-com,send-ext-com"
+          # Remaining attributes will use the default values
+        }
+      }
+    },
+    "1102_1_25" = {
+      l2_port_type     = "port"
+      l3_port_type     = "sub-interface"
+      pod_id           = "1"
+      node_a_id        = "1102"
+      interface_id     = "eth1/25"
+      ip_addr_a        = "172.16.32.14/30"
+      vlan_encap       = "vlan-32"
+      vlan_encap_scope = "local"
+      mode             = "regular"
+      mtu              = "9216"
+
+      bgp_peers = {
+        "core01" = {
+          peer_ip_addr     = "172.16.32.13"
+          peer_asn         = "65032"
+          addr_family_ctrl = "af-ucast"
+          bgp_ctrl         = "send-com,send-ext-com"
+          # Remaining attributes will use the default values
+        }
+      }
+    }
+  }
+
+  external_l3epg = {
+    "default" = {
+      name         = "default"
+      pref_gr_memb = "exclude"
+      subnets = {
+        "default" = {
+          prefix = "0.0.0.0/0"
+          scope  = ["import-security"]
+        }
+      }
+    }
+  }
+}

--- a/examples/l3out/l3out_bgp_port_subif_loopback.tf
+++ b/examples/l3out/l3out_bgp_port_subif_loopback.tf
@@ -1,0 +1,93 @@
+module "bgp01_l3out" {
+  source = "./.."
+
+  name        = "bgp01_l3out"
+  alias       = ""
+  description = "L3Out-BGP-Port-Subif-loopback"
+  tenant_dn   = aci_tenant.test.id
+  vrf_dn      = aci_vrf.test.id
+  l3dom_dn    = data.aci_l3_domain_profile.core.id
+
+  bgp = {
+    enabled = true
+    bgp_peers = {
+      "key" = {
+        peer_ip_addr     = "172.16.31.1"
+        peer_asn         = "65031"
+        addr_family_ctrl = "af-ucast"
+        bgp_ctrl         = "send-com,send-ext-com"
+        peer_ctrl        = "dis-conn-check"
+        # Remaining attributes will use the default values
+      }
+    }
+  }
+
+  nodes = {
+    "1101" = {
+      pod_id             = "1"
+      node_id            = "1101"
+      router_id          = "1.1.1.101"
+      router_id_loopback = "no"
+      loopbacks          = ["172.16.31.101"]
+      static_routes = {
+        "bgp_peer" = {
+          prefix    = "172.16.31.1/32"
+          next_hops = ["172.16.31.9"]
+        }
+      }
+    },
+    "1102" = {
+      pod_id             = "1"
+      node_id            = "1102"
+      router_id          = "1.1.1.102"
+      router_id_loopback = "no"
+      loopbacks          = ["172.16.31.102"]
+      static_routes = {
+        "bgp_peer" = {
+          prefix    = "172.16.31.1/32"
+          next_hops = ["172.16.31.13"]
+        }
+      }
+    }
+  }
+
+  interfaces = {
+    "1101_1_25" = {
+      l2_port_type     = "port"
+      l3_port_type     = "sub-interface"
+      pod_id           = "1"
+      node_a_id        = "1101"
+      interface_id     = "eth1/25"
+      ip_addr_a        = "172.16.31.10/30"
+      vlan_encap       = "vlan-31"
+      vlan_encap_scope = "local"
+      mode             = "regular"
+      mtu              = "9216"
+    },
+    "1102_1_25" = {
+      l2_port_type     = "port"
+      l3_port_type     = "sub-interface"
+      pod_id           = "1"
+      node_a_id        = "1102"
+      interface_id     = "eth1/25"
+      ip_addr_a        = "172.16.31.14/30"
+      vlan_encap       = "vlan-31"
+      vlan_encap_scope = "local"
+      mode             = "regular"
+      mtu              = "9216"
+    }
+  }
+
+  external_l3epg = {
+    "default" = {
+      name         = "default"
+      pref_gr_memb = "exclude"
+      subnets = {
+        "default" = {
+          prefix = "0.0.0.0/0"
+          scope  = ["import-security"]
+        }
+      }
+    }
+  }
+}

--- a/examples/l3out/l3out_bgp_vpc_svi_direct.tf
+++ b/examples/l3out/l3out_bgp_vpc_svi_direct.tf
@@ -1,0 +1,69 @@
+module "bgp04_l3out" {
+  source = "./.."
+
+  name        = "bgp04_l3out"
+  alias       = ""
+  description = "L3Out-BGP-vPC-svi-direct"
+  tenant_dn   = aci_tenant.test.id
+  vrf_dn      = aci_vrf.test.id
+  l3dom_dn    = data.aci_l3_domain_profile.core.id
+
+  bgp = {
+    enabled = true
+  }
+
+  nodes = {
+    "1101" = {
+      pod_id             = "1"
+      node_id            = "1101"
+      router_id          = "1.1.1.101"
+      router_id_loopback = "no"
+    },
+    "1102" = {
+      pod_id             = "1"
+      node_id            = "1102"
+      router_id          = "1.1.1.102"
+      router_id_loopback = "no"
+    }
+  }
+
+  interfaces = {
+    "vpc_core" = {
+      l2_port_type     = "vpc"
+      l3_port_type     = "ext-svi"
+      pod_id           = "1"
+      node_a_id        = "1101"
+      node_b_id        = "1102"
+      interface_id     = "vpc_core"
+      ip_addr_a        = "172.16.34.101/24"
+      ip_addr_b        = "172.16.34.102/24"
+      vlan_encap       = "vlan-34"
+      vlan_encap_scope = "local"
+      mode             = "regular"
+      mtu              = "9216"
+
+      bgp_peers = {
+        "core01" = {
+          peer_ip_addr     = "172.16.34.1"
+          peer_asn         = "65034"
+          addr_family_ctrl = "af-ucast"
+          bgp_ctrl         = "send-com,send-ext-com"
+          # Remaining attributes will use the default values
+        }
+      }
+    }
+  }
+
+  external_l3epg = {
+    "default" = {
+      name         = "default"
+      pref_gr_memb = "exclude"
+      subnets = {
+        "default" = {
+          prefix = "0.0.0.0/0"
+          scope  = ["import-security"]
+        }
+      }
+    }
+  }
+}

--- a/examples/l3out/l3out_ospf_pc_subif_stub.tf
+++ b/examples/l3out/l3out_ospf_pc_subif_stub.tf
@@ -1,0 +1,57 @@
+module "ospf02_l3out" {
+  source = "./.."
+
+  name        = "ospf02_l3out"
+  alias       = ""
+  description = "L3Out-OSPF-PC-Subif-stub"
+  tenant_dn   = aci_tenant.test.id
+  vrf_dn      = aci_vrf.test.id
+  l3dom_dn    = data.aci_l3_domain_profile.core.id
+
+  ospf = {
+    enabled   = true
+    area_id   = "0.0.0.7"
+    area_type = "stub"
+    area_cost = "1"
+    # area_ctrl ommited, takes default value
+  }
+
+  nodes = {
+    "1101" = {
+      pod_id             = "1"
+      node_id            = "1101"
+      router_id          = "1.1.1.101"
+      router_id_loopback = "no"
+    }
+  }
+
+  interfaces = {
+    "pc_core" = {
+      l2_port_type     = "pc"
+      l3_port_type     = "sub-interface"
+      pod_id           = "1"
+      node_a_id        = "1101"
+      interface_id     = "pc_core"
+      ip_addr_a        = "172.16.37.2/30"
+      vlan_encap       = "vlan-37"
+      vlan_encap_scope = "local"
+      mode             = "regular"
+      mtu              = "9216"
+
+      ospf_interface_policy_dn = aci_ospf_interface_policy.ospf_pol.id
+    }
+  }
+
+  external_l3epg = {
+    "default" = {
+      name         = "default"
+      pref_gr_memb = "exclude"
+      subnets = {
+        "default" = {
+          prefix = "0.0.0.0/0"
+          scope  = ["import-security"]
+        }
+      }
+    }
+  }
+}

--- a/examples/l3out/l3out_ospf_port_subif_regular.tf
+++ b/examples/l3out/l3out_ospf_port_subif_regular.tf
@@ -1,0 +1,77 @@
+module "ospf01_l3out" {
+  source = "./.."
+
+  name        = "ospf01_l3out"
+  alias       = ""
+  description = "L3Out-OSPF-Port-Subif-regular"
+  tenant_dn   = aci_tenant.test.id
+  vrf_dn      = aci_vrf.test.id
+  l3dom_dn    = data.aci_l3_domain_profile.core.id
+
+  ospf = {
+    enabled   = true
+    area_id   = "0.0.0.1"
+    area_type = "regular"
+    area_cost = "1"
+    # area_ctrl ommited, takes default value
+  }
+
+  nodes = {
+    "1101" = {
+      pod_id             = "1"
+      node_id            = "1101"
+      router_id          = "1.1.1.101"
+      router_id_loopback = "no"
+    },
+    "1102" = {
+      pod_id             = "1"
+      node_id            = "1102"
+      router_id          = "1.1.1.102"
+      router_id_loopback = "no"
+    }
+  }
+
+  interfaces = {
+    "1101_1_25" = {
+      l2_port_type     = "port"
+      l3_port_type     = "sub-interface"
+      pod_id           = "1"
+      node_a_id        = "1101"
+      interface_id     = "eth1/25"
+      ip_addr_a        = "172.16.36.10/30"
+      vlan_encap       = "vlan-36"
+      vlan_encap_scope = "local"
+      mode             = "regular"
+      mtu              = "9216"
+
+      ospf_interface_policy_dn = aci_ospf_interface_policy.ospf_pol.id
+    },
+    "1102_1_25" = {
+      l2_port_type     = "port"
+      l3_port_type     = "sub-interface"
+      pod_id           = "1"
+      node_a_id        = "1102"
+      interface_id     = "eth1/25"
+      ip_addr_a        = "172.16.36.14/30"
+      vlan_encap       = "vlan-36"
+      vlan_encap_scope = "local"
+      mode             = "regular"
+      mtu              = "9216"
+
+      ospf_interface_policy_dn = aci_ospf_interface_policy.ospf_pol.id
+    }
+  }
+
+  external_l3epg = {
+    "default" = {
+      name         = "default"
+      pref_gr_memb = "exclude"
+      subnets = {
+        "default" = {
+          prefix = "0.0.0.0/0"
+          scope  = ["import-security"]
+        }
+      }
+    }
+  }
+}

--- a/examples/l3out/tenant_test.tf
+++ b/examples/l3out/tenant_test.tf
@@ -1,0 +1,52 @@
+terraform {
+  required_providers {
+    aci = {
+      source  = "CiscoDevNet/aci"
+      version = "2.0.0"
+    }
+  }
+  required_version = "~> 1.1.0"
+}
+
+variable "aci_username" {}
+
+variable "aci_password" {}
+
+variable "aci_url" {}
+
+provider "aci" {
+  # cisco-aci user name
+  username = var.aci_username
+  # cisco-aci password
+  password = var.aci_password
+  # cisco-aci url
+  url      = var.aci_url
+  insecure = true
+}
+
+resource "aci_tenant" "test" {
+  name = "tf_test_tn"
+}
+
+resource "aci_vrf" "test" {
+  name      = "test_vrf"
+  tenant_dn = aci_tenant.test.id
+}
+
+data "aci_l3_domain_profile" "core" {
+  name = "core_l3dom"
+}
+
+resource "aci_ospf_interface_policy" "ospf_pol" {
+  tenant_dn = aci_tenant.test.id
+  name      = "p2p_ospf"
+  nw_t      = "p2p"
+}
+
+
+
+
+
+
+
+

--- a/l3out/README.md
+++ b/l3out/README.md
@@ -1,0 +1,192 @@
+# terraform-aci-l3out
+
+This module creates a L3Out with all the objects included in it, using a similar set of configuration options as the ones available in the l3out wizard available in the UI
+
+* Supported protocols are OSPF, BGP and static.
+* Supported L2 interface types are "port", "pc" and "vpc"
+* Supported L3 interface types are "l3-port", "sub-interface" and "ext-svi"
+* BGP peers can be defined either at interface level or node profile level (local interface used is loopback)
+
+:warning: **This module uses experimental features:** module_variable_optional_attrs
+
+## Usage
+
+### Example for L3Out using OSPF
+
+```hcl
+module "l3out" {
+  source   = "github.com/adealdag/terraform-aci-l3out"
+
+  name        = "core_l3out"
+  alias       = ""
+  description = "L3Out to core network"
+  tenant_dn   = aci_tenant.prod.id
+  vrf_dn      = aci_vrf.prod.id
+  l3dom_dn    = aci_l3_domain_profile.core.id
+
+  ospf = {
+    enabled   = true
+    area_id   = "0.0.0.1"
+    area_type = "regular"
+    area_cost = "1"
+    # area_ctrl ommited, takes default value
+  }
+
+  nodes = {
+    "1101" = {
+      pod_id             = "1"
+      node_id            = "1101"
+      router_id          = "1.1.1.101"
+      router_id_loopback = "no"
+    },
+    "1102" = {
+      pod_id             = "1"
+      node_id            = "1102"
+      router_id          = "1.1.1.102"
+      router_id_loopback = "no"
+    }
+  }
+
+  interfaces = {
+    "1101_1_25" = {
+      l2_port_type     = "port"
+      l3_port_type     = "sub-interface"
+      pod_id           = "1"
+      node_a_id        = "1101"
+      interface_id     = "eth1/25"
+      ip_addr_a        = "172.16.21.10/30"
+      vlan_encap       = "vlan-21"
+      vlan_encap_scope = "local"
+      mode             = "regular"
+      mtu              = "9216"
+
+      ospf_interface_policy_dn = aci_ospf_interface_policy.ospf_p2p.id
+    },
+    "1102_1_25" = {
+      l2_port_type     = "port"
+      l3_port_type     = "sub-interface"
+      pod_id           = "1"
+      node_a_id        = "1102"
+      interface_id     = "eth1/25"
+      ip_addr_a        = "172.16.21.14/30"
+      vlan_encap       = "vlan-21"
+      vlan_encap_scope = "local"
+      mode             = "regular"
+      mtu              = "9216"
+
+      ospf_interface_policy_dn = aci_ospf_interface_policy.ospf_p2p.id
+    }
+  }
+
+  external_l3epg = {
+    "default" = {
+      name         = "default"
+      pref_gr_memb = "exclude"
+      subnets = {
+        "default" = {
+          prefix = "0.0.0.0/0"
+          scope  = ["import-security"]
+        }
+      }
+    }
+  }
+}
+```
+
+### Example for L3Out using BGP and loopbacks as source interface
+
+```hcl
+module "l3out" {
+  source   = "github.com/adealdag/terraform-aci-l3out"
+
+  name        = "core_l3out"
+  alias       = ""
+  description = "L3Out to core network"
+  tenant_dn   = aci_tenant.prod.id
+  vrf_dn      = aci_vrf.prod.id
+  l3dom_dn    = data.aci_l3_domain_profile.core.id
+
+  bgp = {
+    enabled   = true
+    bgp_peers = {
+      "key" = {
+        peer_ip_addr          = "172.16.22.1"
+        peer_asn              = "65022"
+        addr_family_ctrl      = "af-ucast"
+        bgp_ctrl              = "send-com,send-ext-com"
+        peer_ctrl             = "dis-conn-check"
+        # Remaining attributes will use the default values
+      }
+    }
+  }
+
+  nodes = {
+    "1101" = {
+      pod_id             = "1"
+      node_id            = "1101"
+      router_id          = "1.1.1.101"
+      router_id_loopback = "no"
+      loopbacks = ["172.16.22.101"]
+      static_routes = {
+        "bgp_peer" = {
+          prefix = "172.16.22.1/32"
+          next_hops = ["172.16.22.9"]
+        }
+      }
+    },
+    "1102" = {
+      pod_id             = "1"
+      node_id            = "1102"
+      router_id          = "1.1.1.102"
+      router_id_loopback = "no"
+      loopbacks = ["172.16.22.102"]
+      static_routes = {
+        "bgp_peer" = {
+          prefix = "172.16.22.1/32"
+          next_hops = ["172.16.22.13"]
+        }
+      }
+    }
+  }
+
+  interfaces = {
+    "1101_1_25" = {
+      l2_port_type     = "port"
+      l3_port_type     = "sub-interface"
+      pod_id           = "1"
+      node_a_id        = "1101"
+      interface_id     = "eth1/25"
+      ip_addr_a        = "172.16.22.10/30"
+      vlan_encap       = "vlan-22"
+      vlan_encap_scope = "local"
+      mode             = "regular"
+      mtu              = "9216"
+    },
+    "1102_1_25" = {
+      l2_port_type     = "port"
+      l3_port_type     = "sub-interface"
+      pod_id           = "1"
+      node_a_id        = "1102"
+      interface_id     = "eth1/25"
+      ip_addr_a        = "172.16.22.14/30"
+      vlan_encap       = "vlan-22"
+      vlan_encap_scope = "local"
+      mode             = "regular"
+      mtu              = "9216"
+    }
+  }
+
+  external_l3epg = {
+    "default" = {
+      name         = "default"
+      pref_gr_memb = "exclude"
+      subnets = {
+        "default" = {
+          prefix = "0.0.0.0/0"
+          scope  = ["import-security"]
+        }
+      }
+    }
+  }
+}
+```

--- a/l3out/defaults.tf
+++ b/l3out/defaults.tf
@@ -1,0 +1,54 @@
+locals {
+  ospf = defaults(var.ospf, {
+    area_id   = "0.0.0.1"
+    area_type = "nssa"
+    area_cost = "1"
+    area_ctrl = "redistribute,summary"
+  })
+
+  bgp = defaults(var.bgp, {
+    bgp_peers = {
+      weight                = "0"
+      addr_family_ctrl      = "af-ucast"
+      bgp_ctrl              = ""
+      peer_ctrl             = ""
+      allowed_self_as_count = "3"
+      private_as_ctrl       = ""
+      ttl                   = "1"
+    }
+  })
+
+  nodes = defaults(var.nodes, {
+    pod_id             = "1"
+    router_id_loopback = "yes"
+    static_routes = {
+      preference = "1"
+      bfd        = false
+    }
+  })
+
+  interfaces = defaults(var.interfaces, {
+    vlan_encap       = "unknown"
+    vlan_encap_scope = "local"
+    mode             = "regular"
+    mtu              = "inherit"
+
+    bgp_peers = {
+      weight                = "0"
+      addr_family_ctrl      = "af-ucast"
+      bgp_ctrl              = ""
+      peer_ctrl             = ""
+      allowed_self_as_count = "3"
+      private_as_ctrl       = ""
+      ttl                   = "1"
+    }
+  })
+
+  external_l3epg = defaults(var.external_l3epg, {
+    pref_gr_memb = "exclude"
+    subnets = {
+      scope = "import-security"
+    }
+  })
+
+}

--- a/l3out/main.tf
+++ b/l3out/main.tf
@@ -1,0 +1,310 @@
+terraform {
+  experiments = [module_variable_optional_attrs]
+
+  required_providers {
+    aci = {
+      source  = "CiscoDevNet/aci"
+      version = ">= 2.0.0"
+    }
+  }
+
+  required_version = "> 0.14"
+}
+
+locals {
+  # Loopbacks under nodes
+  loopbacks = flatten([
+    for node_key, node_value in local.nodes : [
+      for loopback in node_value.loopbacks : {
+        node_key      = node_key
+        loopback_key  = "${node_key}_${loopback}"
+        loopback_addr = loopback
+      }
+    ]
+    if node_value.loopbacks != null
+  ])
+
+  # Static routes under nodes
+  static_routes = flatten([
+    for node_key, node_value in local.nodes : [
+      for strt_key, strt_value in node_value.static_routes : {
+        node_key            = node_key
+        static_route_key    = "${node_key}_${strt_key}"
+        static_route_config = strt_value
+      }
+    ]
+    #if node_value.static_routes != null
+  ])
+
+  # Static routes next hops
+  strt_next_hops = flatten([
+    for node_key, node_value in local.nodes : [
+      for strt_key, strt_value in node_value.static_routes : [
+        for nh in strt_value.next_hops : {
+          node_key         = node_key
+          static_route_key = "${node_key}_${strt_key}"
+          next_hop_key     = "${node_key}_${strt_key}_${nh}"
+          next_hop_addr    = nh
+        }
+      ]
+      if strt_value.next_hops != null
+    ]
+    #if node_value.static_routes != null
+  ])
+
+  # Interface BGP Peers
+  if_bgp_peers = flatten([
+    for if_key, if_value in local.interfaces : [
+      for peer_key, peer_value in if_value.bgp_peers : {
+        interface_key     = if_key
+        interface_l2_type = if_value.l2_port_type
+        bgp_peer_key      = "${if_key}_${peer_key}"
+        bgp_peer_config   = peer_value
+      }
+    ]
+    if if_value.bgp_peers != null
+  ])
+
+  # L3InstP (L3 EPG) Subnets
+  l3epg_subnets = flatten([
+    for l3epg_key, l3epg_value in local.external_l3epg : [
+      for subnet_key, subnet_value in l3epg_value.subnets : {
+        l3epg_key  = l3epg_key
+        subnet_key = "${l3epg_key}_${subnet_key}"
+        subnet     = subnet_value
+      }
+    ]
+  ])
+}
+
+# L3Out Definition
+resource "aci_l3_outside" "l3out" {
+  tenant_dn                    = var.tenant_dn
+  name                         = var.name
+  name_alias                   = var.alias
+  description                  = var.description
+  relation_l3ext_rs_ectx       = var.vrf_dn
+  relation_l3ext_rs_l3_dom_att = var.l3dom_dn
+}
+
+resource "aci_l3out_ospf_external_policy" "ospf" {
+  count = local.ospf.enabled ? 1 : 0
+
+  l3_outside_dn = aci_l3_outside.l3out.id
+  area_id       = local.ospf.area_id
+  area_type     = local.ospf.area_type
+  area_cost     = local.ospf.area_cost
+  # Doing split as defaults() is not working as expected with list of strings
+  area_ctrl = compact(split(",", local.ospf.area_ctrl))
+}
+
+resource "aci_l3out_bgp_external_policy" "bgp" {
+  count = local.bgp.enabled ? 1 : 0
+
+  l3_outside_dn = aci_l3_outside.l3out.id
+}
+
+resource "aci_bgp_peer_connectivity_profile" "node_bgp_peer" {
+  for_each = local.bgp.bgp_peers
+
+  parent_dn = aci_logical_node_profile.l3np.id
+
+  addr                = each.value.peer_ip_addr
+  as_number           = each.value.peer_asn
+  weight              = each.value.weight
+  addr_t_ctrl         = compact(split(",", each.value.addr_family_ctrl))
+  ctrl                = compact(split(",", each.value.bgp_ctrl))
+  peer_ctrl           = compact(split(",", each.value.peer_ctrl))
+  allowed_self_as_cnt = each.value.allowed_self_as_count
+  local_asn           = each.value.local_asn
+  local_asn_propagate = each.value.local_asn_propagate
+  private_a_sctrl     = compact(split(",", each.value.private_as_ctrl))
+  ttl                 = each.value.ttl
+}
+
+# Nodes Section
+
+resource "aci_logical_node_profile" "l3np" {
+  l3_outside_dn = aci_l3_outside.l3out.id
+
+  name = "${var.name}_nodeProfile"
+}
+
+resource "aci_logical_node_to_fabric_node" "l3np_node" {
+  for_each = local.nodes
+
+  logical_node_profile_dn = aci_logical_node_profile.l3np.id
+  tdn                     = "topology/pod-${each.value.pod_id}/node-${each.value.node_id}"
+  rtr_id                  = each.value.router_id
+  rtr_id_loop_back        = each.value.router_id_loopback
+}
+
+resource "aci_l3out_loopback_interface_profile" "loopback" {
+  for_each = {
+    for loopback in local.loopbacks : loopback.loopback_key => loopback
+  }
+
+  fabric_node_dn = aci_logical_node_to_fabric_node.l3np_node[each.value.node_key].id
+  addr           = each.value.loopback_addr
+}
+
+resource "aci_l3out_static_route" "static" {
+  for_each = {
+    for strt in local.static_routes : strt.static_route_key => strt
+  }
+
+  fabric_node_dn = aci_logical_node_to_fabric_node.l3np_node[each.value.node_key].id
+  ip             = each.value.static_route_config.prefix
+  aggregate      = "no"
+  pref           = each.value.static_route_config.preference
+  rt_ctrl        = each.value.static_route_config.bfd ? "bfd" : "unspecified"
+}
+
+resource "aci_l3out_static_route_next_hop" "nh" {
+  for_each = {
+    for nh in local.strt_next_hops : nh.next_hop_key => nh
+  }
+
+  static_route_dn      = aci_l3out_static_route.static[each.value.static_route_key].id
+  nh_addr              = each.value.next_hop_addr
+  pref                 = "unspecified"
+  nexthop_profile_type = "prefix"
+}
+
+# Interfaces Section
+
+resource "aci_logical_interface_profile" "l3ip" {
+  for_each = local.interfaces
+
+  logical_node_profile_dn = aci_logical_node_profile.l3np.id
+  name                    = "${each.key}_intProfile"
+}
+
+resource "aci_l3out_path_attachment" "path" {
+  for_each = {
+    for if_key, if_value in local.interfaces : if_key => if_value
+    if if_value.l2_port_type != "vpc"
+  }
+
+  logical_interface_profile_dn = aci_logical_interface_profile.l3ip[each.key].id
+  target_dn                    = "topology/pod-${each.value.pod_id}/paths-${each.value.node_a_id}/pathep-[${each.value.interface_id}]"
+  if_inst_t                    = each.value.l3_port_type
+  addr                         = each.value.ip_addr_a
+  mtu                          = each.value.mtu
+  encap                        = each.value.vlan_encap
+  encap_scope                  = each.value.vlan_encap_scope
+  mode                         = each.value.mode
+}
+
+resource "aci_l3out_path_attachment" "protpath" {
+  for_each = {
+    for if_key, if_value in local.interfaces : if_key => if_value
+    if if_value.l2_port_type == "vpc"
+  }
+
+  logical_interface_profile_dn = aci_logical_interface_profile.l3ip[each.key].id
+  target_dn                    = "topology/pod-${each.value.pod_id}/protpaths-${each.value.node_a_id}-${each.value.node_b_id}/pathep-[${each.value.interface_id}]"
+  if_inst_t                    = each.value.l3_port_type
+  addr                         = "0.0.0.0"
+  mtu                          = each.value.mtu
+  encap                        = each.value.vlan_encap
+  encap_scope                  = each.value.vlan_encap_scope
+  mode                         = each.value.mode
+  autostate                    = "enabled"
+}
+
+resource "aci_l3out_vpc_member" "vpc_member_a" {
+  for_each = {
+    for if_key, if_value in local.interfaces : if_key => if_value
+    if if_value.l2_port_type == "vpc"
+  }
+
+  leaf_port_dn = aci_l3out_path_attachment.protpath[each.key].id
+  side         = "A"
+  addr         = each.value.ip_addr_a
+}
+
+resource "aci_l3out_vpc_member" "vpc_member_b" {
+  for_each = {
+    for if_key, if_value in local.interfaces : if_key => if_value
+    if if_value.l2_port_type == "vpc"
+  }
+
+  leaf_port_dn = aci_l3out_path_attachment.protpath[each.key].id
+  side         = "B"
+  addr         = each.value.ip_addr_b
+}
+
+resource "aci_l3out_path_attachment_secondary_ip" "vpc_secondary_addr" {
+  for_each = {
+    for if_key, if_value in local.interfaces : if_key => if_value
+    if if_value.l2_port_type == "vpc" && if_value.ip_addr_shared != null
+  }
+
+  l3out_path_attachment_dn = aci_l3out_path_attachment.protpath[each.key].id
+  addr                     = each.value.ip_addr_shared
+}
+
+# OSPF Interface Policies
+
+resource "aci_l3out_ospf_interface_profile" "ifProf" {
+  for_each = {
+    for if_key, if_value in local.interfaces : if_key => if_value
+    if local.ospf.enabled
+  }
+
+  logical_interface_profile_dn = aci_logical_interface_profile.l3ip[each.key].id
+  auth_type                    = "none"
+  auth_key                     = ""
+  relation_ospf_rs_if_pol      = each.value.ospf_interface_policy_dn
+}
+
+# BGP Peers under Interface
+resource "aci_bgp_peer_connectivity_profile" "if_bgp_peer" {
+  for_each = {
+    for peer in local.if_bgp_peers : peer.bgp_peer_key => peer
+  }
+
+  # Here we are using the BGP Peer under node profile for configuring it under logical interface. Class and atttributes are the same so hopping it works well
+  parent_dn = (each.value.interface_l2_type == "vpc" ?
+  aci_l3out_path_attachment.protpath[each.value.interface_key].id : aci_l3out_path_attachment.path[each.value.interface_key].id)
+
+  addr                = each.value.bgp_peer_config.peer_ip_addr
+  as_number           = each.value.bgp_peer_config.peer_asn
+  weight              = each.value.bgp_peer_config.weight
+  addr_t_ctrl         = compact(split(",", each.value.bgp_peer_config.addr_family_ctrl))
+  ctrl                = compact(split(",", each.value.bgp_peer_config.bgp_ctrl))
+  peer_ctrl           = compact(split(",", each.value.bgp_peer_config.peer_ctrl))
+  allowed_self_as_cnt = each.value.bgp_peer_config.allowed_self_as_count
+  local_asn           = each.value.bgp_peer_config.local_asn
+  local_asn_propagate = each.value.bgp_peer_config.local_asn_propagate
+  private_a_sctrl     = compact(split(",", each.value.bgp_peer_config.private_as_ctrl))
+  ttl                 = each.value.bgp_peer_config.ttl
+}
+
+# External Network Instance Profiles
+resource "aci_external_network_instance_profile" "l3epg" {
+  for_each = local.external_l3epg
+
+  l3_outside_dn          = aci_l3_outside.l3out.id
+  name                   = each.value.name
+  pref_gr_memb           = each.value.pref_gr_memb
+  relation_fv_rs_prov    = each.value.prov_contracts
+  relation_fv_rs_cons    = each.value.cons_contracts
+  relation_fv_rs_cons_if = each.value.cons_imported_contracts
+}
+
+resource "aci_l3_ext_subnet" "l3ext_subnet_default" {
+  for_each = {
+    for subnet in local.l3epg_subnets : subnet.subnet_key => subnet
+  }
+  external_network_instance_profile_dn = aci_external_network_instance_profile.l3epg[each.value.l3epg_key].id
+  ip                                   = each.value.subnet.prefix
+  scope                                = each.value.subnet.scope
+  aggregate                            = each.value.subnet.aggregate
+}
+
+
+
+
+

--- a/l3out/output.tf
+++ b/l3out/output.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = aci_l3_outside.l3out.id
+}

--- a/l3out/variables.tf
+++ b/l3out/variables.tf
@@ -1,0 +1,121 @@
+variable "name" {
+
+}
+
+variable "alias" {
+  default = ""
+}
+
+variable "description" {
+  default = ""
+}
+
+variable "tenant_dn" {
+
+}
+
+variable "vrf_dn" {
+
+}
+
+variable "l3dom_dn" {
+
+}
+
+variable "ospf" {
+  type = object({
+    enabled   = bool
+    area_id   = optional(string)
+    area_type = optional(string)
+    area_cost = optional(string)
+    area_ctrl = optional(string)
+  })
+  default = { enabled = false }
+}
+
+variable "bgp" {
+  type = object({
+    enabled = bool
+    bgp_peers = optional(map(object({
+      peer_ip_addr          = string
+      peer_asn              = string
+      weight                = optional(string)
+      addr_family_ctrl      = optional(string)
+      bgp_ctrl              = optional(string)
+      peer_ctrl             = optional(string)
+      allowed_self_as_count = optional(string)
+      local_asn             = optional(string)
+      local_asn_propagate   = optional(string)
+      private_as_ctrl       = optional(string)
+      ttl                   = optional(string)
+    })))
+  })
+  default = { enabled = false }
+}
+
+
+variable "nodes" {
+  type = map(object({
+    pod_id             = optional(string)
+    node_id            = string
+    router_id          = string
+    router_id_loopback = optional(string)
+    loopbacks          = optional(list(string))
+
+    static_routes = optional(map(object({
+      prefix     = string
+      preference = optional(string)
+      bfd        = optional(bool)
+      next_hops  = optional(list(string))
+    })))
+  }))
+}
+
+variable "interfaces" {
+  type = map(object({
+    l2_port_type     = string
+    l3_port_type     = string
+    pod_id           = string
+    node_a_id        = string
+    node_b_id        = optional(string)
+    interface_id     = string
+    ip_addr_a        = string
+    ip_addr_b        = optional(string)
+    ip_addr_shared   = optional(string)
+    vlan_encap       = optional(string)
+    vlan_encap_scope = optional(string)
+    mode             = optional(string)
+    mtu              = optional(string)
+
+    bgp_peers = optional(map(object({
+      peer_ip_addr          = string
+      peer_asn              = string
+      weight                = optional(string)
+      addr_family_ctrl      = optional(string)
+      bgp_ctrl              = optional(string)
+      peer_ctrl             = optional(string)
+      allowed_self_as_count = optional(string)
+      local_asn             = optional(string)
+      local_asn_propagate   = optional(string)
+      private_as_ctrl       = optional(string)
+      ttl                   = optional(string)
+    })))
+
+    ospf_interface_policy_dn = optional(string)
+  }))
+}
+
+variable "external_l3epg" {
+  type = map(object({
+    name         = string
+    pref_gr_memb = optional(string)
+    subnets = map(object({
+      prefix    = string
+      scope     = optional(list(string))
+      aggregate = optional(string)
+    }))
+    prov_contracts          = optional(set(string))
+    cons_contracts          = optional(set(string))
+    cons_imported_contracts = optional(set(string))
+  }))
+}


### PR DESCRIPTION
### Description
Added L3out module that provides a similar look and feel as the UI wizard we provide in APIC. In other words, it allows user to configure a L3Out with either static routing, BGP or OSPF with the most typically used options.

### Considerations
This module uses an experimental feature to allow defining optional input variables together with default values, in order to simplify its use and allow users to define only what they need (and leave other input variables blank).

### Testing performed
All the provided examples has been tested in a real fabric:

- APIC release: 5.2(2f)
- Terraform version: 1.1.5
- Provider version: 2.0.0
